### PR TITLE
docs: fix install url

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ How to use:
 ```json
 {
   "devDependencies": {
-    "@types/ember-data": "github:feederco/ember-data-types#master"
+    "@types/ember-data": "github:feederco/ember-data-types#main"
   }
 }
 ```


### PR DESCRIPTION
The current one errors as the branch `master` doesn't exist.